### PR TITLE
Add support for older versions of debian (12,11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Enhanced Bash Configuration
 
 # FOR THE DEV TO READ! 
-fastfetch and 1 other package didnt exist in debian 12 repos. it gives the OPTION to skip installing neofetch (and it still works!)
+fastfetch and 1 other package didnt exist in debian 12 repos. it gives the OPTION to skip installing fastfetch (and it still works!) photo below
+[bash](https://copyparty.blahaj.dedyn.io/images/IMG_3434.jpeg)
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Enhanced Bash Configuration
 
+# FOR THE DEV TO READ! 
+fastfetch and 1 other package didnt exist in debian 12 repos. it gives the OPTION to skip installing neofetch (and it still works!)
+
 ## Overview
 
 A comprehensive `.bashrc` configuration with modern terminal enhancements for Unix-like systems. This setup provides powerful aliases, custom functions, an enhanced prompt, and integrated tools to significantly improve your terminal productivity and experience.


### PR DESCRIPTION
hello. this gives the option to skip installing fastfetch/antigen as they didn't exist in older versions of debian! newer versions can still install them though, this just adds compatibility 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a top-level developer note about optional tools on Debian 12 and a reference image; no functional changes.

* **Bug Fixes**
  * Installer no longer fails when optional components are missing; proceeds with clear, non-fatal warnings.
  * Configuration for optional tools only runs when those tools are present.
  * Quieter, clearer logging for optional installs.

* **Behavior**
  * Improved handling of elevated/privileged operations to be more robust across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->